### PR TITLE
Only save username cache if an update operation is performed

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/grouptagbot/GroupTagListener.java
+++ b/src/main/java/pro/zackpollard/telegrambot/grouptagbot/GroupTagListener.java
@@ -31,12 +31,11 @@ public class GroupTagListener implements Listener {
         User sender = event.getMessage().getSender();
 
         if(sender != null) {
-
-            manager.getUsernameCache().updateUsername(sender.getId(), sender.getUsername());
+            if (manager.getUsernameCache().updateUsername(sender.getId(), sender.getUsername())) {
+                instance.getManager().saveUsernameCache();
+                instance.getManager().saveTags();
+            }
         }
-
-        instance.getManager().saveUsernameCache();
-        instance.getManager().saveTags();
     }
 
     @Override

--- a/src/main/java/pro/zackpollard/telegrambot/grouptagbot/data/UsernameCache.java
+++ b/src/main/java/pro/zackpollard/telegrambot/grouptagbot/data/UsernameCache.java
@@ -17,11 +17,14 @@ public class UsernameCache {
         this.usernameCache = new TreeMap<>();
     }
 
-    public void updateUsername(Long userID, String newUsername) {
+    // returns true if an update operation was performed
+    public boolean updateUsername(Long userID, String newUsername) {
 
         if(newUsername != null && !newUsername.equals("")) {
             if (newUsername.charAt(0) == '@') newUsername = newUsername.substring(1);
-            this.usernameCache.put(userID, newUsername.toLowerCase());
+            return this.usernameCache.put(userID, newUsername.toLowerCase()) != null;
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
This significantly decreases the amount of File I/O as it only writes to file when a username was changed, not after any message has been sent.
